### PR TITLE
Various misc improvements to spawns and formatting.

### DIFF
--- a/CVARINFO.txt
+++ b/CVARINFO.txt
@@ -1,3 +1,18 @@
+// AI Tweaks. - [Ted]
 server bool tango_recklessrocket = true;
 server bool tango_crackshot = true;
 server bool tango_crouch = true;
+
+// Spawning options. - [Ted]
+server float partygoon_chaingunner_weight = 1.5;
+server float partygoon_demon_weight = 3;
+server float partygoon_jackboot_weight = 20;
+server float partygoon_zombieman_weight = 5;
+server float partygoon_hoopbubble_weight = 0.5;
+
+// Whether to spawn at all, or not. - [Ted]
+server bool partygoon_chaingunner_enabled = true;
+server bool partygoon_demon_enabled = false;
+server bool partygoon_jackboot_enabled = false;
+server bool partygoon_zombieman_enabled = false;
+server bool partygoon_hoopbubble_enabled = false;

--- a/HDCINFO.txt
+++ b/HDCINFO.txt
@@ -1,5 +1,12 @@
 // HDCore Lib Spawntable definition file
-// add HDPartyGoon to the chaingunner spawntable!
-addSpawnTableSingleEntry => { "tableName": "ChaingunGuyReplaces", "name": "HDPartyGoon", "weight": "1", "persists": "true" }
-// add a slight extra bias to UndeadRifleman as well!
-addSpawnTableSingleEntry => { "tableName": "ChaingunGuyReplaces", "name": "UndeadRifleman", "weight": "1", "persists": "true" }
+
+// New HDPartyGoon spawn table entries.
+addSpawnTableSingleEntry => { "tableName": "ChaingunGuyReplaces", "name": "HDPartyGoon", "weight": "#partygoon_chaingunner_weight", "persists": "true", "enabled": "#partygoon_chaingunner_enabled" }
+addSpawnTableSingleEntry => { "tableName": "DemonReplaces", "name": "HDPartyGoon", "weight": "#partygoon_demon_weight", "persists": "true", "enabled": "#partygoon_demon_enabled" }
+addSpawnTableSingleEntry => { "tableName": "ShotgunGuyReplaces", "name": "HDPartyGoon", "weight": "#partygoon_jackboot_weight", "persists": "true", "enabled": "#partygoon_jackboot_enabled" }
+addSpawnTableSingleEntry => { "tableName": "ZombieManReplaces", "name": "HDPartyGoon", "weight": "#partygoon_zombieman_weight", "persists": "true", "enabled": "#partygoon_zombieman_enabled" }
+addSpawnTableSingleEntry => { "tableName": "WolfensteinSSReplaces", "name": "HDPartyGoon", "weight": "#partygoon_hoopbubble_weight", "persists": "true", "enabled": "#partygoon_hoopbubble_enabled" }
+
+// Change the weight of the UndeadRifleman Entry. - [Ted]
+// This should probably be a CVAR, though I'm just gonna link it to if they're enabled via chaingunner spawns.
+setSpawnTableEntryWeight => { "tableName": "ChaingunGuyReplaces", "name": "UndeadRifleman", "weight": "3", "enabled": "#partygoon_chaingunner_enabled" }

--- a/MENUDEF.txt
+++ b/MENUDEF.txt
@@ -1,16 +1,55 @@
-AddOptionMenu "HDAddonMenu" {
+AddOptionMenu "HDAddonMenu"
+{
 	SubMenu "GoonParty Settings","TangoSettings"
 }
-OptionMenu "TangoSettings" {
+
+AddOptionMenu "OptionsMenu"
+{
+	SubMenu "GoonParty Settings","TangoSettings"
+}
+
+OptionMenu "TangoSettings"
+{
 	Title "GoonParty Settings"
-	StaticText " "
+	SubMenu "Spawning Options", "TangoSpawning"
+	StaticText ""
 	Option "Reckless rockets", "tango_recklessrocket", "YesNo"
 	StaticText "Rare AI types will occasionally launch really rude rockets."
-	StaticText " "
+	StaticText ""
 	Option "Crackshot tangos", "tango_crackshot", "YesNo"
 	StaticText "Goons aim faster and hit right where they aim."
-	StaticText " "
+	StaticText ""
 	Option "Crouching", "tango_crouch", "YesNo"
 	StaticText "Goons sometimes crouch when under fire or attacking."
-	StaticText " "
+}
+
+OptionMenu "TangoSpawning"
+{
+	Title "GoonParty Spawning"
+	StaticText "Spawning Options", "Yellow"
+	StaticText ""
+	StaticText "Goon Chaingunner Spawn Options", "White"
+	Option "Spawns Enabled: ", "partygoon_chaingunner_enabled", "YesNo"
+	Slider "Spawn Weight: ", "partygoon_chaingunner_weight", 0.0, 100, .01, 2
+	SafeCommand "Reset Chaingunner Weight", "resetcvar partygoon_chaingunner_weight"
+	StaticText ""
+	StaticText "Goon Demon Spawn Options", "White"
+	Option "Spawns Enabled: ", "partygoon_demon_enabled", "YesNo"
+	Slider "Spawn Weight: ", "partygoon_Demon_weight", 0.0, 100, .01, 2
+	SafeCommand "Reset Demon Weight", "resetcvar partygoon_Demon_weight"
+	StaticText ""
+	StaticText "Goon Jackboot Spawn Options", "White"
+	Option "Spawns Enabled: ", "partygoon_jackboot_enabled", "YesNo"
+	Slider "Spawn Weight: ", "partygoon_Jackboot_weight", 0.0, 100, .01, 2
+	SafeCommand "Reset Jackboot Weight", "resetcvar partygoon_Jackboot_weight"
+	StaticText ""
+	StaticText "Goon Zombieman Spawn Options", "White"
+	Option "Spawns Enabled: ", "partygoon_zombieman_enabled", "YesNo"
+	Slider "Spawn Weight: ", "partygoon_Zombieman_weight", 0.0, 100, .01, 2
+	SafeCommand "Reset Zombieman Weight", "resetcvar partygoon_Zombieman_weight"
+	StaticText ""
+	StaticText "Goon Hoopbubble Spawn Options", "White"
+	Option "Spawns Enabled: ", "partygoon_hoopbubble_enabled", "YesNo"
+	Slider "Spawn Weight: ", "partygoon_Hoopbubble_weight", 0.0, 100, .01, 2
+	SafeCommand "Reset Hoopbubble Weight", "resetcvar partygoon_Hoopbubble_weight"
 }

--- a/README.md
+++ b/README.md
@@ -1,0 +1,1 @@
+# Goon Party

--- a/filter/doom.id.doom1/HDCINFO.txt
+++ b/filter/doom.id.doom1/HDCINFO.txt
@@ -1,4 +1,0 @@
-// HDCore Lib Spawntable definition file
-// filter file only for id doom1
-// since chaingunners don't spawn in doom1, add tangos to the demon spawntable instead!
-addSpawnTableSingleEntry => { "tableName": "DemonReplaces", "name": "HDPartyGoon", "weight": "2", "persists": "true" }

--- a/zscript.zsc
+++ b/zscript.zsc
@@ -1,7 +1,7 @@
 //=======================================
 //Let's Tango.
 //=======================================
-version "4.10.0"
+version "4.10"
 class HDTangoEventHandler:eventhandler{
 	override void CheckReplacement(replaceevent e){
 		/*if(e.replacee is "chaingunguy"){


### PR DESCRIPTION
## Changes:
- Adds proper comments to various files missing it
- Changes the main zscript lump file extension to .zsc to help external editors figure out if it's zscript or not.
- Adds in user-customizable cvars for both where a party goon should spawn and how frequently they should spawn, based on HDCoreLib's weighted spawns.
- Updates the menu to look a bit cleaner and include the Spawning options.
- Removes the unnecessary Doom1 filter.